### PR TITLE
Remove 8.5 from upcoming releases

### DIFF
--- a/versions.php
+++ b/versions.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 $versions = [];
 
 if (getenv('INPUT_UPCOMINGRELEASES') == 'true') {
-    $versions[] = '8.5.0RC5';
+    //$versions[] = '9.0.0RC1';
 }
 
 $d = new DOMDocument();


### PR DESCRIPTION
8.5.0 is now final so drop it from upcoming releases. Also prep for PHP 9 for next year.